### PR TITLE
add new headers to allow for cookie auth

### DIFF
--- a/controllers.js
+++ b/controllers.js
@@ -14,6 +14,10 @@ exports.embed = function *() {
     var config = gu.config.types[this.request.query.type];
     var {embed} = this.request.body;
 
+    // this may break existing usage so am commenting out
+    // this.set("Access-Control-Allow-Origin", "https://charts.local.dev-gutools.co.uk"),
+    // this.set("Vary", "Origin"), 
+    // this.set('Access-Control-Allow-Credentials', 'true')
     this.set('Access-Control-Allow-Origin', '*');
     this.set('Access-Control-Allow-Headers', 'X-Requested-With, Content-Type, Accept, Origin, Access-Control-Request-Headers');
     this.set('Access-Control-Allow-Methods', 'POST, OPTIONS');
@@ -40,9 +44,11 @@ exports.embed = function *() {
 };
 
 exports.cors = function *() {
- this.set('Access-Control-Allow-Origin', '*');
+    this.set("Access-Control-Allow-Origin", "https://charts.local.dev-gutools.co.uk"),
+    this.set("Vary", "Origin"),
     this.set('Access-Control-Allow-Headers', 'X-Requested-With, Content-Type, Accept, Origin, Access-Control-Request-Headers');
     this.set('Access-Control-Allow-Methods', 'POST, OPTIONS');
+    this.set('Access-Control-Allow-Credentials', 'true');
     this.body = '';
 };
 


### PR DESCRIPTION
According to this Cors documentation https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
We need to add `Access-Control-Allow-Credentials` if we want to use cookie auth. And also need to specify an exact `Access-Control-Allow-Origin`.

Am only applying to the CORS call so as not to break the tool. 