### PR TITLE
CORS FIX ATTEMPT: Add Origin Header to main request

### DIFF
--- a/controllers.js
+++ b/controllers.js
@@ -15,12 +15,8 @@ exports.embed = function *() {
     var {embed} = this.request.body;
 
     // this may break existing usage so am commenting out
-    // this.set("Access-Control-Allow-Origin", "https://charts.local.dev-gutools.co.uk"),
-    // this.set("Vary", "Origin"), 
-    // this.set('Access-Control-Allow-Credentials', 'true')
-    this.set('Access-Control-Allow-Origin', '*');
-    this.set('Access-Control-Allow-Headers', 'X-Requested-With, Content-Type, Accept, Origin, Access-Control-Request-Headers');
-    this.set('Access-Control-Allow-Methods', 'POST, OPTIONS');
+    this.set("Access-Control-Allow-Origin", "https://charts.gutools.co.uk"),
+    this.set('Access-Control-Allow-Credentials', 'true')
 
     if (config) {
         let key = moment().format('MMM/YYYY-MM-DDTHH:mm:ss').replace(/(^\w{3})/, a => a.toLowerCase());
@@ -45,7 +41,7 @@ exports.embed = function *() {
 
 exports.cors = function *() {
     this.set("Access-Control-Allow-Origin", "https://charts.gutools.co.uk"),
-    this.set("Vary", "Origin"),
+    // this.set("Vary", "Origin"),
     this.set('Access-Control-Allow-Headers', 'X-Requested-With, Content-Type, Accept, Origin, Access-Control-Request-Headers');
     this.set('Access-Control-Allow-Methods', 'POST, OPTIONS');
     this.set('Access-Control-Allow-Credentials', 'true');


### PR DESCRIPTION
Another attempt to fix the CORS issue: adding `Access-Control-Allow-Origin` to the second request. 

This may break existing use of the charts tool so may need to be reverted. 
