### PR TITLE
BUG: comment out all origin headers

### DIFF
--- a/controllers.js
+++ b/controllers.js
@@ -14,8 +14,8 @@ exports.embed = function *() {
     var config = gu.config.types[this.request.query.type];
     var {embed} = this.request.body;
 
-    this.set('Access-Control-Allow-Origin', '*');
-    this.set('Access-Control-Allow-Credentials', 'true')
+    // this.set('Access-Control-Allow-Origin', '*');
+    // this.set('Access-Control-Allow-Credentials', 'true')
 
     gu.log.info("EMBED Function, request is:", this)
 


### PR DESCRIPTION
Origin headers of any value in the live tool seem to cause 500 errors. 

Removing them